### PR TITLE
Add environment to Errbit POST body

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -14,6 +14,7 @@ defmodule Airbrakex.Notifier do
     payload = %{}
     |> add_notifier
     |> add_error(error)
+    |> add_environment
     |> add_context(Keyword.get(options, :context))
     |> add(:session, Keyword.get(options, :session))
     |> add(:params, Keyword.get(options, :params))
@@ -30,6 +31,10 @@ defmodule Airbrakex.Notifier do
   defp add_error(payload, nil), do: payload
   defp add_error(payload, error) do
     payload |> Dict.put(:errors, [error])
+  end
+
+  defp add_environment(payload) do
+    payload |> Dict.put(:environment, %{})
   end
 
   defp add_context(payload, nil) do

--- a/lib/airbrakex/plug.ex
+++ b/lib/airbrakex/plug.ex
@@ -16,11 +16,17 @@ defmodule Airbrakex.Plug do
           exception ->
             session = Map.get(conn.private, :plug_session)
 
-            Airbrakex.ExceptionParser.parse(exception)
-            |> Airbrakex.Notifier.notify([params: conn.params, session: session])
+            if logging_enabled? do
+              Airbrakex.ExceptionParser.parse(exception)
+              |> Airbrakex.Notifier.notify([params: conn.params, session: session])
+            end
 
             reraise exception, System.stacktrace
         end
+      end
+
+      defp logging_enabled? do
+        Enum.member?(Application.get_env(:airbrakex, :logging_enabled_environments), Mix.env)
       end
     end
   end


### PR DESCRIPTION
The request currently fails unless the `environment` property is also passed along in the request body.  The tests still pass.
