### PR TITLE
Add environment to Errbit POST body

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -14,6 +14,7 @@ defmodule Airbrakex.Notifier do
     payload = %{}
     |> add_notifier
     |> add_error(error)
+    |> add_environment
     |> add_context(Keyword.get(options, :context))
     |> add(:session, Keyword.get(options, :session))
     |> add(:params, Keyword.get(options, :params))
@@ -30,6 +31,10 @@ defmodule Airbrakex.Notifier do
   defp add_error(payload, nil), do: payload
   defp add_error(payload, error) do
     payload |> Dict.put(:errors, [error])
+  end
+
+  defp add_environment(payload) do
+    payload |> Dict.put(:environment, %{})
   end
 
   defp add_context(payload, nil) do


### PR DESCRIPTION
This separates the commit out from https://github.com/fazibear/airbrakex/pull/3, which adds final compatibility with Errbit.
