### PR TITLE
Fix errbit notification

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -17,7 +17,7 @@ defmodule Airbrakex.Notifier do
     |> add_context(Keyword.get(options, :context))
     |> add(:session, Keyword.get(options, :session))
     |> add(:params, Keyword.get(options, :params))
-    |> add(:environment, Keyword.get(options, :environment))
+    |> add(:environment, Keyword.get(options, :environment, %{}))
     |> Poison.encode!
 
     post(url, payload, @request_headers)

--- a/test/airbrakex/exception_parser_test.exs
+++ b/test/airbrakex/exception_parser_test.exs
@@ -2,31 +2,22 @@ defmodule Airbrakex.ExceptionParserTest do
   use ExUnit.Case
 
   test "should parse exception" do
-
     exception = try do
       IO.inspect("test",[],"")
     rescue
       e -> e
     end
 
-    result = %{
-      backtrace: [
-        %{file: "(Elixir.IO) lib/io.ex", function: "inspect(\"test\", [], \"\")", line: 209},
-        %{file: "(Elixir.Airbrakex.ExceptionParserTest) test/airbrakex/exception_parser_test.exs", function: "test should parse exception/1", line: 7},
-        %{file: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "exec_test/1", line: 293}, %{file: "(timer) timer.erl", function: "tc/1", line: 166},
-        %{file: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "-spawn_test/3-fun-1-/3", line: 242}
-      ],
-      message: "no function clause matching in IO.inspect/3",
-      type: FunctionClauseError
-    }
-
-    %{
+    expected = %{
       backtrace: [],
       message: "no function clause matching in IO.inspect/3",
       type: FunctionClauseError
     }
+    actual = Airbrakex.ExceptionParser.parse(exception)
 
-    assert Airbrakex.ExceptionParser.parse(exception) == result
+    assert [_head | _tail] = actual.backtrace
+    assert actual.message == expected.message
+    assert actual.type == expected.type
   end
 end
 

--- a/test/airbrakex/exception_parser_test.exs
+++ b/test/airbrakex/exception_parser_test.exs
@@ -11,10 +11,10 @@ defmodule Airbrakex.ExceptionParserTest do
 
     result = %{
       backtrace: [
-        %{file: "(Elixir.IO) lib/io.ex", function: "inspect(\"test\", [], \"\")", line: 201},
+        %{file: "(Elixir.IO) lib/io.ex", function: "inspect(\"test\", [], \"\")", line: 209},
         %{file: "(Elixir.Airbrakex.ExceptionParserTest) test/airbrakex/exception_parser_test.exs", function: "test should parse exception/1", line: 7},
-        %{file: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "exec_test/2", line: 253}, %{file: "(timer) timer.erl", function: "tc/1", line: 166},
-        %{file: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "-spawn_test/3-fun-1-/3", line: 201}
+        %{file: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "exec_test/1", line: 293}, %{file: "(timer) timer.erl", function: "tc/1", line: 166},
+        %{file: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "-spawn_test/3-fun-1-/3", line: 242}
       ],
       message: "no function clause matching in IO.inspect/3",
       type: FunctionClauseError


### PR DESCRIPTION
This fixes two problems:
1. Airbrake notifications not working on newer Errbit instances (I used #4 as the reference for this but implemented and tested the suggestion from @fazibear)
2. Fixed up the test in test/airbrakex/exception_parser_test.exs to not fail on different versions of Elixir. I am instead asserting that the backtrace is not empty, and that the message and type match.
