### PR TITLE
Back to poison 1.5 and some errbit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Then run `mix deps.get` in your shell to fetch the dependencies.
 It requires `project_key` and `project` parameters to be set
 in your application environment, usually defined in your `config/config.exs`.
 `logger_level` and `environment` are optional.
-If you want to use errbit instance, set custom url as endpoint.
+
+If you want to use errbit instance, set custom url as `endpoint`.
 
 ```elixir
 config :airbrakex,
@@ -33,6 +34,19 @@ config :airbrakex,
   environment: Mix.env,
   endpoint: "http://errbit.yourdomain.com"
 ```
+
+For production environments **is not recommended using Mix.env as value**, it will fail if you don't include :mix as a dependency (Mix is supposed to be used only in dev or build envs). 
+
+You can use something like this instead:
+
+In `config/prod.exs` or `config/prod.secret.exs`
+```elixir
+config :airbrakex,
+  ...
+  environment: :prod
+  ...
+```
+
 
 ## Usage
 

--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -17,7 +17,7 @@ defmodule Airbrakex.Notifier do
     |> add_context(Keyword.get(options, :context))
     |> add(:session, Keyword.get(options, :session))
     |> add(:params, Keyword.get(options, :params))
-    |> add(:environment, Keyword.get(options, :environment, %{}))
+    |> add(:environment, Keyword.get(options, :environment, %{empty: true}))
     |> Poison.encode!
 
     post(url, payload, @request_headers)

--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -33,12 +33,12 @@ defmodule Airbrakex.Notifier do
   end
 
   defp add_context(payload, nil) do
-    payload |> Dict.put(:context, %{environment: Application.get_env(:airbrakex, :environment, Mix.env)})
+    payload |> Dict.put(:context, %{environment: Application.get_env(:airbrakex, :environment, :prod)})
   end
 
   defp add_context(payload, context) do
     if !context[:environment] do
-      context = context |> Dict.put(:environment, Application.get_env(:airbrakex, :environment, Mix.env))
+      context = context |> Dict.put(:environment, Application.get_env(:airbrakex, :environment, :prod))
     end
     if !context[:language] do
       context = context |> Dict.put(:language, "Elixir")

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Airbrakex.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.8"},
-      {:poison, "~> 2.0"}
+      {:poison, "~> 1.5"}
     ]
   end
 end


### PR DESCRIPTION
Hello!

You can see in the commit messages what I've included here. I've reverted back to poison 1.5 because too many other hex packages depend on 1.5 yet causing a lot of dependency conflicts (at least on my projects).

I don't know if it's better to branch this because of this poison dependency or there are some other way of having compatibility with both 1.5 and 2.0 poison versions.

I'm a newbie on elixir so don't know if a `{:poison, "~> 1.5 or ~> 2.0"}` whould do the trick.

Thanks
