### PR TITLE
Fix `Poison` versioning and application list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,14 +22,14 @@ defmodule Airbrakex.Mixfile do
 
   def application do
     [
-      applications: [:idna, :hackney, :httpoison]
+      applications: [:poison, :httpoison]
     ]
   end
 
   defp deps do
     [
       {:httpoison, "~> 0.8"},
-      {:poison, "~> 2.0"}
+      {:poison, "~> 1.5 or ~> 2.0"}
     ]
   end
 end


### PR DESCRIPTION
`idna` is inside `hackney`s applications list, so there is no need to put it to your applications list.
So instead of `idna` and `hackney` I put just `httpoison` which has `hackney` which it turn has `idna` in their applications list.

Also I've added `poison` to the applications list.

With the following list `[:idna, :hackney, :httpoison]` my exrm releases don't want to be built. 

And `~> 1.5 or ~> 2.0` is better than just `~> 2.0`.
