### PR TITLE
Use Map functions instead of Dict

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -25,35 +25,38 @@ defmodule Airbrakex.Notifier do
   end
 
   defp add_notifier(payload) do
-    payload |> Dict.put(:notifier, @info)
+    payload |> Map.put(:notifier, @info)
   end
 
   defp add_error(payload, nil), do: payload
   defp add_error(payload, error) do
-    payload |> Dict.put(:errors, [error])
+    payload |> Map.put(:errors, [error])
   end
 
   defp add_context(payload, nil) do
-    payload |> Dict.put(:context, %{environment: Application.get_env(:airbrakex, :environment, @default_env)})
+    payload |> Map.put(:context, %{environment: airbrakex_environment})
   end
 
   defp add_context(payload, context) do
-    if !context[:environment] do
-      context = context |> Dict.put(:environment, Application.get_env(:airbrakex, :environment, @default_env))
-    end
-    if !context[:language] do
-      context = context |> Dict.put(:language, "Elixir")
-    end
-    payload |> Dict.put(:context, context)
+    context =
+      context
+      |> Map.put_new(:environment, airbrakex_environment)
+      |> Map.put_new(:language, "Elixir")
+
+    payload |> Map.put(:context, context)
   end
 
   defp add(payload, _key, nil), do: payload
-  defp add(payload, key, value), do: Dict.put(payload, key, value)
+  defp add(payload, key, value), do: Map.put(payload, key, value)
 
   defp url do
     project_id = Application.get_env(:airbrakex, :project_id)
     project_key = Application.get_env(:airbrakex, :project_key)
     endpoint = Application.get_env(:airbrakex, :endpoint, @default_endpoint)
     "#{endpoint}/api/v3/projects/#{project_id}/notices?key=#{project_key}"
+  end
+
+  defp airbrakex_environment do
+    Application.get_env(:airbrakex, :environment, @default_env)
   end
 end


### PR DESCRIPTION
`airbrakex/notifier.ex` prints some warnings when compiled in the newest Elixir, and uses the deprecated module `Dict` instead of `Map`.

here I fix the warnings, if you wish 😉

```
warning: the variable "context" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/airbrakex/notifier.ex:44

warning: the variable "context" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/airbrakex/notifier.ex:45

warning: the variable "context" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/airbrakex/notifier.ex:47
```
