### PR TITLE
Accept delayed config (System runtime)

### DIFF
--- a/lib/airbrakex/config.ex
+++ b/lib/airbrakex/config.ex
@@ -1,0 +1,39 @@
+defmodule Airbrakex.Config do
+  @moduledoc """
+  This module handles smart fetching values from the config
+  """
+
+  @doc """
+  Fetches a value from config, or environment if {:system, "VAR"} is provided.
+  An optional default value can be provided, if desired.
+  """
+  @spec get(atom, atom, term | nil) :: term
+  def get(app, key, default \\ nil) when is_atom(app) and is_atom(key) do
+    app
+    |> Application.get_env(key)
+    |> get_config(default)
+  end
+
+  defp get_config({:system, env_var}, default) do
+    case env_var |> System.get_env do
+      nil ->
+        default
+
+      value ->
+        value
+    end
+  end
+
+  defp get_config({:system, env_var, preconfigured_default}, _default) do
+    case env_var |> System.get_env do
+      nil ->
+        preconfigured_default
+
+      value ->
+        value
+    end
+  end
+
+  defp get_config(nil, default), do: default
+  defp get_config(value, _default), do: value
+end

--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -1,5 +1,6 @@
 defmodule Airbrakex.Notifier do
   use HTTPoison.Base
+  alias Airbrakex.Config
 
   @request_headers [{"Content-Type", "application/json"}]
   @default_endpoint "http://collect.airbrake.io"
@@ -49,14 +50,14 @@ defmodule Airbrakex.Notifier do
   defp add(payload, key, value), do: payload |> Map.put(key, value)
 
   defp url do
-    project_id = Application.get_env(:airbrakex, :project_id)
-    project_key = Application.get_env(:airbrakex, :project_key)
-    endpoint = Application.get_env(:airbrakex, :endpoint, @default_endpoint)
+    project_id = Config.get(:airbrakex, :project_id)
+    project_key = Config.get(:airbrakex, :project_key)
+    endpoint = Config.get(:airbrakex, :endpoint, @default_endpoint)
 
     "#{endpoint}/api/v3/projects/#{project_id}/notices?key=#{project_key}"
   end
 
   defp environment do
-    Application.get_env(:airbrakex, :environment, @default_env)
+    Config.get(:airbrakex, :environment, @default_env)
   end
 end


### PR DESCRIPTION
With Mix configs being evaluated at build time, only an `Application.put_env` at boot can set project id and key on the context of the production machine.

This PR allows the config to be passed as `config :airbrakex, project_id: {:system, "AIRBRAKE_PROJECT_ID"}`, indicating it will be evaluated at runtime, using system environment variables.
