### PR TITLE
Fix LoggerBackend.handle_event to handle (ignore) :flush event.

### DIFF
--- a/lib/airbrakex/logger_backend.ex
+++ b/lib/airbrakex/logger_backend.ex
@@ -12,7 +12,7 @@ defmodule Airbrakex.LoggerBackend do
 
   use GenEvent
 
-  alias Airbrakex.{LoggerBackend, Notifier}
+  alias Airbrakex.{LoggerBackend, LoggerParser, Notifier}
 
   def init(__MODULE__) do
     {:ok, configure([])}

--- a/lib/airbrakex/logger_backend.ex
+++ b/lib/airbrakex/logger_backend.ex
@@ -33,6 +33,10 @@ defmodule Airbrakex.LoggerBackend do
     {:ok, state}
   end
 
+  def handle_event(:flush, state) do
+    {:ok, state}
+  end
+
   defp proceed?({Logger, _msg, _ts, meta}) do
     Keyword.get(meta, :airbrakex, true)
   end

--- a/lib/airbrakex/logger_backend.ex
+++ b/lib/airbrakex/logger_backend.ex
@@ -12,7 +12,7 @@ defmodule Airbrakex.LoggerBackend do
 
   use GenEvent
 
-  alias Airbrakex.{LoggerBackend, LoggerParser, Notifier}
+  alias Airbrakex.{LoggerParser, Notifier}
 
   def init(__MODULE__) do
     {:ok, configure([])}


### PR DESCRIPTION
This PR fixes `LoggerBackend.handle_event` to handle (ignore) the `:flush` event.

According to [the official docs for `Logger`](http://elixir-lang.org/docs/stable/logger/Logger.html):

> Once initialized, the handler should be designed to handle events in the following format:

```elixir
{level, group_leader, {Logger, message, timestamp, metadata}} | :flush
```

Not sure if this is a new requirement as of recent versions of Elixir, but at any rate it shouldn't cause any problems with older versions that did not send the `:flush` method, since it is only being ignored.

This PR resolves errors I was seeing when the `:flush` event was not matching any known clause of the `handle_event` function.

---

EDIT: Also added another commit to the PR that adds a missing alias - `LoggerParser` is used from the `LoggerBackend` module but was not previously aliased there.