### PR TITLE
Fix Enum.filter_map/3 deprecation

### DIFF
--- a/lib/airbrakex/logger_parser.ex
+++ b/lib/airbrakex/logger_parser.ex
@@ -6,26 +6,41 @@ defmodule Airbrakex.LoggerParser do
 
   def parse(msg) do
     type = Regex.named_captures(@type_regex, msg)["type"]
+    lines = String.split(msg, "\n")
 
-    messages = Enum.filter_map String.split(msg, "\n"),
-          &(!Regex.match?(@stacktrace_regex, &1) &&
-            !Regex.match?(@exception_header_regex, &1)), fn(line) ->
+    message =
+      lines
+      |> Enum.filter(&message?/1)
+      |> Enum.map(fn line -> Regex.replace(@type_regex, line, "") end)
+      |> Enum.join("\n")
 
-              Regex.replace(@type_regex, line, "")
-    end
-
-    backtrace = Enum.filter_map String.split(msg, "\n"),
-        &(Regex.match?(@stacktrace_regex, &1)), fn(line) ->
-
-      hash = Regex.named_captures(@stacktrace_regex, line)
-      {line, _} = Integer.parse(hash["line"])
-      %{hash | "line" => line}
-    end
+    backtrace =
+      lines
+      |> Enum.filter(&stacktrace?/1)
+      |> Enum.map(&backtrace_line/1)
 
     %{
       type: type,
-      message: Enum.join(messages, "\n"),
+      message: message,
       backtrace: backtrace
     }
+  end
+
+  defp message?(line) do
+    !stacktrace?(line) && !exception_header?(line)
+  end
+
+  defp stacktrace?(line) do
+    Regex.match?(@stacktrace_regex, line)
+  end
+
+  defp exception_header?(line) do
+    Regex.match?(@exception_header_regex, line)
+  end
+
+  defp backtrace_line(line) do
+    hash = Regex.named_captures(@stacktrace_regex, line)
+    {line, _} = Integer.parse(hash["line"])
+    %{hash | "line" => line}
   end
 end


### PR DESCRIPTION
This PR fixes the warnings on the deprecation for `Enum.filter_map/3` 🙂

```
warning: Enum.filter_map/3 is deprecated, use Enum.filter/2 + Enum.map/2 or for comprehensions
  lib/airbrakex/logger_parser.ex:10

warning: Enum.filter_map/3 is deprecated, use Enum.filter/2 + Enum.map/2 or for comprehensions
  lib/airbrakex/logger_parser.ex:17
```

FYI, there are still compile warnings related to the deprecation of `GenEvent` (not resolved in this PR).

```
warning: use GenEvent is deprecated, use one of the alternatives described in the documentation for the GenEvent module
  lib/airbrakex/logger_backend.ex:13

warning: the GenEvent module is deprecated, see its documentation for alternatives
  lib/airbrakex/logger_backend.ex:13
```