### PR TITLE
Add extra travis test envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: elixir
-
-elixir:
-  - 1.3.4
-
-otp_release:
-  - 19.0
+matrix:
+  include:
+    - otp_release: 19.0
+      elixir: 1.3.4
+    - otp_release: 19.3
+      elixir: 1.3
+    - otp_release: 19.3
+      elixir: 1.4
+    - otp_release: 20.0
+      elixir: 1.4
+    - otp_release: 20.0
+      elixir: 1.5
+sudo: false


### PR DESCRIPTION
Noticed most recent versions of Elixir and OTP are not part of the test suite.

Maintained the version currently used; phoenix has similar config 👍🏼
