### PR TITLE
Fix typo in LoggerBackend

### DIFF
--- a/lib/airbrakex/logger_backend.ex
+++ b/lib/airbrakex/logger_backend.ex
@@ -45,7 +45,7 @@ defmodule Airbrakex.LoggerBackend do
     {:ok, state}
   end
 
-  def termitate(_reason, _state) do
+  def terminate(_reason, _state) do
     :ok
   end
 


### PR DESCRIPTION
`termitate` -> `terminate`