### PR TITLE
Add Plug.Conn url to context

### DIFF
--- a/test/airbrakex/notifier_test.exs
+++ b/test/airbrakex/notifier_test.exs
@@ -1,110 +1,62 @@
 defmodule Airbrakex.NotifierTest do
-  use ExUnit.Case
+  use Airbrakex.TestCase
 
-  @project_id "project_id"
-  @project_key "project_key"
-
-  setup do
-    bypass = Bypass.open()
-    Application.put_env(:airbrakex, :endpoint, "http://localhost:#{bypass.port}")
-    Application.put_env(:airbrakex, :project_id, @project_id)
-    Application.put_env(:airbrakex, :project_key, @project_key)
-
-    error =
-      try do
-        IO.inspect("test", [], "")
-      rescue
-        e -> e
-      end
-
-    {:ok, bypass: bypass, error: error}
-  end
-
-  test "notifies with a proper request", %{bypass: bypass, error: error} do
-    Bypass.expect(bypass, fn conn ->
-      assert "/api/v3/projects/#{@project_id}/notices" == conn.request_path
+  test "notifies with a proper request" do
+    notify fn conn, _params ->
+      assert "/api/v3/projects/project_id/notices" == conn.request_path
       assert "POST" == conn.method
-      assert "key=#{@project_key}" == conn.query_string
+      assert "key=project_key" == conn.query_string
       assert Enum.member?(conn.req_headers, {"content-type", "application/json"})
-
-      Plug.Conn.resp(conn, 200, "")
-    end)
-
-    Airbrakex.Notifier.notify(error)
+    end
   end
 
-  test "notifies with with a proper payload", %{bypass: bypass, error: error} do
-    Bypass.expect(bypass, fn conn ->
-      # Calling parser to populate `body_params`.
-      opts = [parsers: [Plug.Parsers.JSON], json_decoder: Poison]
-      conn = Plug.Parsers.call(conn, Plug.Parsers.init(opts))
-
-      assert Map.has_key?(conn.body_params, "notifier")
-      assert Map.has_key?(conn.body_params, "errors")
-      assert Map.has_key?(conn.body_params, "context")
-      assert Map.has_key?(conn.body_params, "environment")
-
-      Plug.Conn.resp(conn, 200, "")
-    end)
-
-    Airbrakex.Notifier.notify(error)
+  test "notifies with a proper payload" do
+    notify fn _conn, params ->
+      assert Map.has_key?(params, "notifier")
+      assert Map.has_key?(params, "errors")
+      assert Map.has_key?(params, "context")
+      assert Map.has_key?(params, "environment")
+    end
   end
 
-  test "notifies when empty context is provided as an option", %{bypass: bypass, error: error} do
-    Bypass.expect(bypass, fn conn ->
-      opts = [parsers: [Plug.Parsers.JSON], json_decoder: Poison]
-      conn = Plug.Parsers.call(conn, Plug.Parsers.init(opts))
-
-      assert "Elixir" == conn.body_params["context"]["language"]
-      assert "test" == conn.body_params["context"]["environment"]
-
-      Plug.Conn.resp(conn, 200, "")
-    end)
-
-    Airbrakex.Notifier.notify(error, context: %{})
+  test "adds language to context" do
+    notify fn -> Airbrakex.Notifier.notify(error(), context: %{mystuff: "Yo!"}) end, fn _conn, params ->
+      assert "Elixir" == params["context"]["language"]
+    end
   end
 
-  test "notifies with session if it's provided", %{bypass: bypass, error: error} do
-    Bypass.expect(bypass, fn conn ->
-      opts = [parsers: [Plug.Parsers.JSON], json_decoder: Poison]
-      conn = Plug.Parsers.call(conn, Plug.Parsers.init(opts))
-
-      assert %{"foo" => "bar"} == conn.body_params["session"]
-
-      Plug.Conn.resp(conn, 200, "")
-    end)
-
-    Airbrakex.Notifier.notify(error, session: %{foo: "bar"})
+  test "adds environment to context" do
+    notify fn -> Airbrakex.Notifier.notify(error(), context: %{mystuff: "Yo!"}) end, fn _conn, params ->
+      assert "test" == params["context"]["environment"]
+    end
   end
 
-  test "notifies with additional params if they're provided", %{bypass: bypass, error: error} do
-    Bypass.expect(bypass, fn conn ->
-      opts = [parsers: [Plug.Parsers.JSON], json_decoder: Poison]
-      conn = Plug.Parsers.call(conn, Plug.Parsers.init(opts))
-
-      assert %{"foo" => "bar"} == conn.body_params["params"]
-
-      Plug.Conn.resp(conn, 200, "")
-    end)
-
-    Airbrakex.Notifier.notify(error, params: %{foo: "bar"})
+  test "keeps provided context" do
+    notify fn -> Airbrakex.Notifier.notify(error(), context: %{mystuff: "Yo!"}) end, fn _conn, params ->
+      assert "Yo!" == params["context"]["mystuff"]
+    end
   end
 
-  test "evaluates system environment if specified", %{bypass: bypass, error: error} do
+  test "notifies with session if it's provided" do
+    notify fn -> Airbrakex.Notifier.notify(error(), session: %{foo: "bar"}) end, fn _conn, params ->
+      assert %{"foo" => "bar"} == params["session"]
+    end
+  end
+
+  test "notifies with additional params if they're provided" do
+    notify fn -> Airbrakex.Notifier.notify(error(), params: %{foo: "bar"}) end, fn _conn, params ->
+      assert %{"foo" => "bar"} == params["params"]
+    end
+  end
+
+  test "evaluates system environment if specified" do
     System.put_env("AIR_TEST_ID", "airbrakex_id")
     System.put_env("AIR_TEST_KEY", "airbrakex_key")
 
-    Application.put_env(:airbrakex, :project_id, {:system, "AIR_TEST_ID"})
-    Application.put_env(:airbrakex, :project_key, {:system, "AIR_TEST_KEY"})
-
-    Bypass.expect(bypass, fn conn ->
+    notify {:system, "AIR_TEST_ID"}, {:system, "AIR_TEST_KEY"}, fn conn, _params ->
       assert "/api/v3/projects/airbrakex_id/notices" == conn.request_path
       assert "POST" == conn.method
       assert "key=airbrakex_key" == conn.query_string
-
-      Plug.Conn.resp(conn, 200, "")
-    end)
-
-    Airbrakex.Notifier.notify(error)
+    end
   end
 end

--- a/test/airbrakex/plug_test.exs
+++ b/test/airbrakex/plug_test.exs
@@ -1,0 +1,19 @@
+defmodule Airbrakex.TestPlug do
+  use Airbrakex.Plug
+
+  def call(_conn, _opts) do
+    IO.inspect("test", [], "")
+  end
+end
+
+defmodule Airbrakex.PlugTest do
+  use Airbrakex.TestCase
+  use Plug.Test
+
+  test "notifies with request url in context" do
+    notify fn -> Airbrakex.TestPlug.call(conn(:get, "/wat"), %{}) end, fn _conn, params ->
+      %{"context" => context} = params
+      assert "http://www.example.com/wat" == Map.get(context, "url")
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,55 @@
 ExUnit.start()
 
 Application.ensure_all_started(:bypass)
+
+defmodule Airbrakex.TestCase do
+  defmacro __using__(_opts) do
+    quote do
+      use ExUnit.Case
+      import Airbrakex.TestCase
+    end
+  end
+
+  def error do
+    try do error!() rescue e -> e end
+  end
+
+  def error! do
+    IO.inspect("test", [], "")
+  end
+
+  def body_params(conn) do
+    opts = [parsers: [Plug.Parsers.JSON], json_decoder: Poison]
+    Plug.Parsers.call(conn, Plug.Parsers.init(opts)).body_params
+  end
+
+  def notify(verify) do
+    verify_airbrake_notification(verify)
+    Airbrakex.Notifier.notify(error())
+  end
+
+  def notify(work, verify) do
+    verify_airbrake_notification(verify)
+    try do work.() rescue e -> e end
+  end
+
+  def notify(project_id, project_key, verify) do
+    verify_airbrake_notification(project_id, project_key, verify)
+    Airbrakex.Notifier.notify(error())
+  end
+
+  defp bypass_airbrake(project_id, project_key) do
+    bypass = Bypass.open()
+    Application.put_env(:airbrakex, :endpoint, "http://localhost:#{bypass.port}")
+    Application.put_env(:airbrakex, :project_id, project_id)
+    Application.put_env(:airbrakex, :project_key, project_key)
+    bypass
+  end
+
+  defp verify_airbrake_notification(project_id \\ "project_id", project_key \\ "project_key", verify) do
+    Bypass.expect(bypass_airbrake(project_id, project_key), fn conn ->
+      verify.(conn, body_params(conn))
+      Plug.Conn.resp(conn, 200, "")
+    end)
+  end
+end


### PR DESCRIPTION
Exception reports do not currently include the url of the request. This change makes `Airbrakex.Plug` include the url in the context as does the Rails Airbrake gem.

I'd like to use `Plug.Conn.request_url`, but I think the dependency on Plug would need to be optional. Also, `request_url` is only available on Plug `1.5`, which may force folks to update a lot of other things to get `1.5` working. This commit avoids the dependency problem for now by copying in the `Plug.Conn.request_url` code.