### PR TITLE
Fix handle_info callback of logger backend Fix #34

### DIFF
--- a/lib/airbrakex/logger_backend.ex
+++ b/lib/airbrakex/logger_backend.ex
@@ -39,7 +39,7 @@ defmodule Airbrakex.LoggerBackend do
   end
 
   def handle_info(_message, state) do
-    {:noreply, state}
+    {:ok, state}
   end
 
   def code_change(_old_vsn, state, _extra) do

--- a/test/airbrakex/exception_parser_test.exs
+++ b/test/airbrakex/exception_parser_test.exs
@@ -36,6 +36,6 @@ defmodule Airbrakex.ExceptionParserTest do
     assert Enum.member?(backtrace_functions, "test parses exception/1")
     assert Enum.member?(backtrace_functions, "exec_test/1")
     assert Enum.member?(backtrace_functions, "tc/1")
-    assert Enum.member?(backtrace_functions, "-spawn_test/3-fun-1-/3")
+    assert Enum.member?(backtrace_functions, "-spawn_test/3-fun-1-/4")
   end
 end

--- a/test/airbrakex/exception_parser_test.exs
+++ b/test/airbrakex/exception_parser_test.exs
@@ -36,6 +36,10 @@ defmodule Airbrakex.ExceptionParserTest do
     assert Enum.member?(backtrace_functions, "test parses exception/1")
     assert Enum.member?(backtrace_functions, "exec_test/1")
     assert Enum.member?(backtrace_functions, "tc/1")
-    assert Enum.member?(backtrace_functions, "-spawn_test/3-fun-1-/4")
+    if :lt == Version.compare(System.version(), "1.6.0") do
+      assert Enum.member?(backtrace_functions, "-spawn_test/3-fun-1-/3")
+    else
+      assert Enum.member?(backtrace_functions, "-spawn_test/3-fun-1-/4")
+    end
   end
 end


### PR DESCRIPTION
Logger backend are expected to be GenEvent modules. GenEvent modules does not accept `{:noreply, state}` as a response to `handle_info` callbacks.

Therefore, the Airbrakex logger backend is killed with a message `:gen_event_EXIT`