### PR TITLE
REP-5816: add ability to pass ssl options to the http layer

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -24,7 +24,7 @@ defmodule Airbrakex.Notifier do
       |> add(:environment, Keyword.get(options, :environment, %{}))
       |> Poison.encode!()
 
-    post(url(), payload, @request_headers)
+    post(url(), payload, @request_headers, http_options())
   end
 
   defp add_notifier(payload) do
@@ -59,6 +59,13 @@ defmodule Airbrakex.Notifier do
     endpoint = Config.get(:airbrakex, :endpoint, @default_endpoint)
 
     "#{endpoint}/api/v3/projects/#{project_id}/notices?key=#{project_key}"
+  end
+
+  defp http_options do
+    case Config.get(:airbrakex, :ssl) do
+      nil -> []
+      ssl_config -> [ssl: ssl_config]
+    end
   end
 
   defp environment do


### PR DESCRIPTION
Just adding the ability to pass ssl config downstream to HTTPoison. This will (hopefully) fix the problems with squid.