### PR TITLE
Add ability to pass http_options options to the http layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Then run `mix deps.get` in your shell to fetch the dependencies.
 It requires `project_key` and `project` parameters to be set
 in your application environment, usually defined in your `config/config.exs`.
 `logger_level` and `environment` are optional.
-If you want to use errbit instance, set custom url as endpoint.
 
 ```elixir
 config :airbrakex,
@@ -35,7 +34,21 @@ config :airbrakex,
   project_id: 123456,
   logger_level: :error,
   environment: Mix.env,
-  endpoint: "http://errbit.yourdomain.com"
+```
+
+#### Advanced Configuration
+
+If you want to use errbit instance, set custom url as `endpoint`.
+If you connect through a proxy or need to pass other specific options to
+`HTTPoison` you can use `http_options`, see https://hexdocs.pm/httpoison/HTTPoison.html#request/5
+for a list of the available options.
+
+```elixir
+config :airbrakex,
+  project_key: "abcdef12345",
+  project_id: 123456,
+  endpoint: "http://errbit.yourdomain.com",
+  http_options: [ssl: [cacertfile: "/path/to/certfile.pem"]]
 ```
 
 ## Usage

--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -24,7 +24,7 @@ defmodule Airbrakex.Notifier do
       |> add(:environment, Keyword.get(options, :environment, %{}))
       |> Poison.encode!()
 
-    post(url(), payload, @request_headers)
+    post(url(), payload, @request_headers, http_options())
   end
 
   defp add_notifier(payload) do
@@ -59,6 +59,10 @@ defmodule Airbrakex.Notifier do
     endpoint = Config.get(:airbrakex, :endpoint, @default_endpoint)
 
     "#{endpoint}/api/v3/projects/#{project_id}/notices?key=#{project_key}"
+  end
+
+  defp http_options do
+    Config.get(:airbrakex, :http_options) || []
   end
 
   defp environment do

--- a/test/airbrakex/notifier_test.exs
+++ b/test/airbrakex/notifier_test.exs
@@ -107,4 +107,19 @@ defmodule Airbrakex.NotifierTest do
 
     Airbrakex.Notifier.notify(error)
   end
+
+  test "passes http_options to the HTTPoison request", %{bypass: bypass, error: error} do
+    Application.put_env(:airbrakex, :http_options, params: [custom_param: "custom_value"])
+
+    Bypass.expect(bypass, fn conn ->
+      assert "/api/v3/projects/#{@project_id}/notices" == conn.request_path
+      assert "POST" == conn.method
+      assert "key=#{@project_key}&custom_param=custom_value" == conn.query_string
+
+      Plug.Conn.resp(conn, 200, "")
+    end)
+
+    Airbrakex.Notifier.notify(error)
+    Application.delete_env(:airbrakex, :http_options)
+  end
 end


### PR DESCRIPTION
Add the `http_options` config key that would be pass to the `post` request sent to airbrake.

Our use case is we need to specify the certfile, but kept it generic and accept the same `options` as HTTPoision.
 