### PR TITLE
Ensure that ignore works for all notify requests

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -14,17 +14,19 @@ defmodule Airbrakex.Notifier do
   }
 
   def notify(error, options \\ []) do
-    payload =
-      %{}
-      |> add_notifier
-      |> add_error(error)
-      |> add_context(Keyword.get(options, :context))
-      |> add(:session, Keyword.get(options, :session))
-      |> add(:params, Keyword.get(options, :params))
-      |> add(:environment, Keyword.get(options, :environment, %{}))
-      |> Poison.encode!()
+    if proceed?(Application.get_env(:airbrakex, :ignore), error) do
+      payload =
+        %{}
+        |> add_notifier
+        |> add_error(error)
+        |> add_context(Keyword.get(options, :context))
+        |> add(:session, Keyword.get(options, :session))
+        |> add(:params, Keyword.get(options, :params))
+        |> add(:environment, Keyword.get(options, :environment, %{}))
+        |> Poison.encode!()
 
-    post(url(), payload, @request_headers)
+      post(url(), payload, @request_headers)
+    end
   end
 
   defp add_notifier(payload) do
@@ -64,4 +66,11 @@ defmodule Airbrakex.Notifier do
   defp environment do
     Config.get(:airbrakex, :environment, @default_env)
   end
+
+
+  defp proceed?(ignore, _error) when is_nil(ignore), do: true
+  defp proceed?(ignore, error) when is_function(ignore), do: !ignore.(error)
+
+  defp proceed?(ignore, error) when is_list(ignore),
+    do: !Enum.any?(ignore, fn el -> el == error.type end)
 end

--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -67,7 +67,6 @@ defmodule Airbrakex.Notifier do
     Config.get(:airbrakex, :environment, @default_env)
   end
 
-
   defp proceed?(ignore, _error) when is_nil(ignore), do: true
   defp proceed?(ignore, error) when is_function(ignore), do: !ignore.(error)
 

--- a/lib/airbrakex/plug.ex
+++ b/lib/airbrakex/plug.ex
@@ -34,19 +34,13 @@ defmodule Airbrakex.Plug do
 
             error = ExceptionParser.parse(exception)
 
-            if proceed?(Application.get_env(:airbrakex, :ignore), error) do
-              Notifier.notify(error, params: conn.params, session: session)
-            end
+
+            Notifier.notify(error, params: conn.params, session: session)
+
 
             reraise exception, System.stacktrace()
         end
       end
-
-      defp proceed?(ignore, _error) when is_nil(ignore), do: true
-      defp proceed?(ignore, error) when is_function(ignore), do: !ignore.(error)
-
-      defp proceed?(ignore, error) when is_list(ignore),
-        do: !Enum.any?(ignore, fn el -> el == error.type end)
     end
   end
 end

--- a/lib/airbrakex/plug.ex
+++ b/lib/airbrakex/plug.ex
@@ -34,9 +34,7 @@ defmodule Airbrakex.Plug do
 
             error = ExceptionParser.parse(exception)
 
-
             Notifier.notify(error, params: conn.params, session: session)
-
 
             reraise exception, System.stacktrace()
         end

--- a/test/airbrakex/notifier_test.exs
+++ b/test/airbrakex/notifier_test.exs
@@ -9,6 +9,7 @@ defmodule Airbrakex.NotifierTest do
     Application.put_env(:airbrakex, :endpoint, "http://localhost:#{bypass.port}")
     Application.put_env(:airbrakex, :project_id, @project_id)
     Application.put_env(:airbrakex, :project_key, @project_key)
+    Application.put_env(:airbrakex, :ignore, fn(_) -> false end)
 
     error =
       try do
@@ -104,6 +105,14 @@ defmodule Airbrakex.NotifierTest do
 
       Plug.Conn.resp(conn, 200, "")
     end)
+
+    Airbrakex.Notifier.notify(error)
+  end
+
+  test "does not notify if ignore resolves truthy", %{bypass: bypass, error: error} do
+    Application.put_env(:airbrakex, :ignore, fn(_) -> true end)
+
+    Bypass.pass(bypass)
 
     Airbrakex.Notifier.notify(error)
   end


### PR DESCRIPTION
Move the check to ignore into notify, this way when the `:ignore` key is set in config it will work for _all_ requests, not just those handled through the plug.

Closes #38 