### PR TITLE
adding mfa tuple handler to Notifer.proceed/2

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -72,6 +72,7 @@ defmodule Airbrakex.Notifier do
   end
 
   defp proceed?(ignore, _error) when is_nil(ignore), do: true
+  defp proceed?({module, function, []}, error), do: !apply(module, function, [error])
   defp proceed?(ignore, error) when is_function(ignore), do: !ignore.(error)
 
   defp proceed?(ignore, error) when is_list(ignore),

--- a/test/airbrakex/notifier_test.exs
+++ b/test/airbrakex/notifier_test.exs
@@ -116,6 +116,20 @@ defmodule Airbrakex.NotifierTest do
 
     Airbrakex.Notifier.notify(error)
   end
+
+  test "accepts MFA tuple as ignore value", %{bypass: bypass, error: error} do
+    defmodule IgnoreTest do
+      def ignore(_error) do
+        true
+      end
+    end
+
+    Application.put_env(:airbrakex, :ignore, {IgnoreTest, :ignore, []})
+
+    Bypass.pass(bypass)
+
+    Airbrakex.Notifier.notify(error)
+  end
   
   test "passes http_options to the HTTPoison request", %{bypass: bypass, error: error} do
     Application.put_env(:airbrakex, :http_options, params: [custom_param: "custom_value"])


### PR DESCRIPTION
Context: 
Using a capture function in configuration of ignore results in an error when building a release with `MIX_ENV=prod mix release`. 

```
==> Packaging release..
==> Release packaging failed due to errors:
    Cannot add file sys.config to tar file - [{error,{22,erl_parse,["syntax error before: ",["Fun"]]}}]
```
It seems that using the MFA tuple syntax in `config.exs` does not result in this error when building a release, and it would be helpful to allow this syntax as a configuration option. 

This pr adds a handler for this syntax to Notifier.proceed?/2 and an associated test.
