### PR TITLE
Fix unmatched return dialyzer warning

### DIFF
--- a/lib/airbrakex/plug.ex
+++ b/lib/airbrakex/plug.ex
@@ -34,7 +34,7 @@ defmodule Airbrakex.Plug do
 
             error = ExceptionParser.parse(exception)
 
-            Notifier.notify(error, params: conn.params, session: session)
+            _ = Notifier.notify(error, params: conn.params, session: session)
 
             reraise exception, System.stacktrace()
         end


### PR DESCRIPTION
Every project that uses airbrakex as dependency, if wants to use dialyzer with the `unmatched_returns` option, will get one warning from airbrakex:

```
lib/airbrakex/plug.ex:37:unmatched_return
Expression produces a value of type:


  nil
  | {:error, %HTTPoison.Error{:__exception__ => true, :id => nil, :reason => _}}
  | {:ok,
     %{
       :__struct__ => HTTPoison.AsyncResponse | HTTPoison.Response,
       :body => _,
       :headers => [any()],
       :id => reference(),
       :request => %HTTPoison.Request{
         :body => _,
         :headers => _,
         :method => :delete | :get | :head | :options | :patch | :post | :put,
         :options => _,
         :params => _,
         :url => binary()
       },
       :request_url => _,
       :status_code => integer()
     }}


but this value is unmatched.
________________________________________________________________________________
done (warnings were emitted)
```

This solution would silence the warning in all projects using airbrakex. Seems good if your intent is to leave it unmatched. Maybe `opts` could inform if we should fail or not if call errors?