### PR TITLE
update readme to current hex version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Add Airbrakex as a dependency to your `mix.exs` file:
 
 ```elixir
 defp deps do
-  [{:airbrakex, "~> 0.1.3"}]
+  [{:airbrakex, "~> 0.1.6"}]
 end
 ```
 


### PR DESCRIPTION
It looks like the most recent release on Hex is 1.6. It might be a good idea to update the readme so that new users are using the most up to date version of this package. 

Though I would also request that the most recent version according to the mix package here (1.7) gets posted if possible :) see #43 