### PR TITLE
Plug sends up URL error occurred on 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 *.ez
 *.tar
+.tool-versions

--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -36,10 +36,13 @@ defmodule Airbrakex.Notifier do
   defp add_error(payload, nil), do: payload
 
   defp add_error(payload, error) do
-    error = Map.from_struct(error)
+    error = get_error_as_map(error)
 
     payload |> Map.put(:errors, [error])
   end
+
+  defp get_error_as_map(%{__struct__: _} = error), do: Map.from_struct(error)
+  defp get_error_as_map(error), do: error
 
   defp add_context(payload, nil) do
     payload |> Map.put(:context, %{environment: environment()})

--- a/lib/airbrakex/plug.ex
+++ b/lib/airbrakex/plug.ex
@@ -34,7 +34,11 @@ defmodule Airbrakex.Plug do
 
             error = ExceptionParser.parse(exception)
 
-            _ = Notifier.notify(error, params: conn.params, session: session)
+            _ = Notifier.notify(error,
+              params: conn.params,
+              session: session,
+              context: %{url: Plug.Conn.request_url(conn)}
+            )
 
             reraise exception, System.stacktrace()
         end

--- a/test/airbrakex/plug_test.exs
+++ b/test/airbrakex/plug_test.exs
@@ -1,0 +1,53 @@
+defmodule Airbrakex.TestPlug do
+  use Airbrakex.Plug
+
+  def call(_conn, _opts) do
+    IO.inspect("test", [], "")
+  end
+end
+
+defmodule Airbrakex.PlugTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  @project_id "project_id"
+  @project_key "project_key"
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:airbrakex, :endpoint, "http://localhost:#{bypass.port}")
+    Application.put_env(:airbrakex, :project_id, @project_id)
+    Application.put_env(:airbrakex, :project_key, @project_key)
+    Application.put_env(:airbrakex, :ignore, fn _ -> false end)
+
+    error =
+      try do
+        IO.inspect("test", [], "")
+      rescue
+        e -> e
+      end
+
+    {:ok, bypass: bypass, error: error}
+  end
+
+  test "returns hello world", %{bypass: bypass} do
+    Bypass.expect(bypass, fn conn ->
+      opts = [parsers: [Plug.Parsers.JSON], json_decoder: Jason]
+      conn = Plug.Parsers.call(conn, Plug.Parsers.init(opts))
+
+      assert %{"context" => %{"url" => "http://www.example.com/hello"}} = conn.body_params
+
+      Plug.Conn.resp(conn, 200, "")
+    end)
+
+
+    conn = conn(:get, "/hello")
+    |> fetch_query_params()
+
+    try do
+      Airbrakex.TestPlug.call(conn, [])
+    rescue
+      e in FunctionClauseError -> e
+    end
+  end
+end


### PR DESCRIPTION
- Fixes issue with plug not sending error to notifier as struct (closes #51 )
- Adds a test for the plug (hopefully we can catch breaking errors ahead of time now :) )
- Sends up URL from the plug (based on #32 )

cc @fazibear 