### PR TITLE
Fix ignore when it's a list

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -86,15 +86,18 @@ defmodule Airbrakex.Notifier do
 
   defp proceed?(ignore, error) when is_list(ignore) do
     type = error_type(error)
-    !Enum.any?(ignore, &(&1 == type))
+    !Enum.any?(ignore, &(ignore_type(&1) == type))
   end
 
   defp error_type(%{type: type}) when is_binary(type), do: type
   defp error_type(%{type: type}) when is_atom(type), do: to_string(type)
+  defp error_type(%{__struct__: type}) when is_atom(type), do: to_string_type(type)
+  defp error_type(_), do: nil
 
-  defp error_type(%{__struct__: type}) when is_atom(type) do
+  defp ignore_type(type) when is_binary(type), do: type
+  defp ignore_type(type) when is_atom(type), do: to_string_type(type)
+
+  defp to_string_type(type) when is_atom(type) do
     type |> to_string |> String.replace(~r/^Elixir\./, "")
   end
-
-  defp error_type(_), do: nil
 end

--- a/test/airbrakex/notifier_test.exs
+++ b/test/airbrakex/notifier_test.exs
@@ -129,8 +129,6 @@ defmodule Airbrakex.NotifierTest do
 
     error_to_ignore = fetch_error(fn -> raise SpecificError, "A type A error" end)
 
-    Bypass.pass(bypass)
-
     Airbrakex.Notifier.notify(error_to_ignore)
   end
 


### PR DESCRIPTION
My app has `ignore: [Phoenix.Router.NoRouteError]`, but that doesn't filter these errors.

Then I went writing some tests for ignore when it's a list, and saw `notify` didn't work as expected, because it expects the error to have a `.type`, when an exception struct won't have this, it will have its name on `__struct__` map key instead. I don't know if `exception.type` was ever a thing in Elixir, but this code is there for a while.

Also added the `type` key so the error type is not lost in translation.

This still doesn't resolve my problem I guess, since this noroute error doesn't notify the exception itself (`NoRouteError`), but the process exit – anyways, it seems this fixes broken expectations.