### PR TITLE
Update default endpoint to api.airbrake.io

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -4,7 +4,7 @@ defmodule Airbrakex.Notifier do
   alias Airbrakex.Config
 
   @request_headers [{"Content-Type", "application/json"}]
-  @default_endpoint "https://airbrake.io"
+  @default_endpoint "https://api.airbrake.io"
   @default_env Mix.env()
 
   @info %{


### PR DESCRIPTION
airbrake.io endpoint is deprecated and will stop working on May 31st, 2021. api.airbrake.io is the new endpoint.