### PR TITLE
update notifier endpoint to app.airbrake.io

### DIFF
--- a/lib/airbrakex/notifier.ex
+++ b/lib/airbrakex/notifier.ex
@@ -4,7 +4,7 @@ defmodule Airbrakex.Notifier do
   alias Airbrakex.Config
 
   @request_headers [{"Content-Type", "application/json"}]
-  @default_endpoint "https://airbrake.io"
+  @default_endpoint "https://app.airbrake.io"
   @default_env Mix.env()
 
   @info %{


### PR DESCRIPTION
 This is in order to deal with upcoming changes to routing in airbrake. Internally airbrake is changing it's routing for notifiers to app.airbrake.io. 